### PR TITLE
feat(workflow): enable multi-arch images by default

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ on:
       target_platforms:
         description: 'Target platforms for buildx (e.g., linux/amd64,linux/arm64)'
         required: false
-        default: 'linux/amd64'
+        default: 'linux/amd64,linux/arm64'
       skip_unit_tests:
         description: 'Skip unit tests when building this image'
         type: boolean
@@ -58,7 +58,7 @@ jobs:
       ODOO_VERSION: ${{ inputs.odoo_version || '19.0' }}
       ODOO_REPOSITORY: ${{ inputs.odoo_repository || 'https://github.com/odoo/odoo.git' }}
       IMAGE_TAG: ${{ inputs.image_tag || '' }}
-      TARGET_PLATFORMS: ${{ inputs.target_platforms || 'linux/amd64' }}
+      TARGET_PLATFORMS: ${{ inputs.target_platforms || 'linux/amd64,linux/arm64' }}
       SKIP_UNIT_TESTS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_unit_tests || true }}
 
     steps:


### PR DESCRIPTION
Hi,
first off thanks for the repo =)

I noticed that arm64 images aren't published yet, so I added them as default.
It's not tested.
